### PR TITLE
优化Docker镜像构建

### DIFF
--- a/.github/workflows/push-to-docker.yml
+++ b/.github/workflows/push-to-docker.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: build --rm-dist ${{ steps.snapshot.outputs.ARG }}
+          args: build --rm-dist --id docker ${{ steps.snapshot.outputs.ARG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       -
@@ -84,3 +84,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          shm-size: 2g

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,20 @@ builds:
       - -trimpath
     ldflags:
       - -s -w -X main.VERSION=v{{.Version}}
+  - id: docker
+    env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.VERSION=v{{.Version}}
 
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
@@ -87,3 +101,6 @@ nfpms:
       - deb
       - rpm
     maintainer: johlanse
+    builds:
+      - nowin
+      - win

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,22 @@ FROM debian:bullseye-slim
 
 ARG TARGETARCH
 
-COPY ./dist/nowin_linux_$TARGETARCH*/study_xxqg /opt/study_xxqg
+RUN  ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+     echo 'Asia/Shanghai' >/etc/timezone && \
+     apt-get -qq update && \
+     apt-get -qq install -y --no-install-recommends ca-certificates curl && \
+     apt-get install -y libx11-6 libgbm1 libasound2 libcairo2 libxshmfence1 libatspi2.0-0 libpango-1.0-0 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libxrandr2 libxfixes3 libxdamage1 libxcomposite1 libxkbcommon0 && \
+     apt-get clean && \
+     mkdir /opt/config/
 
-RUN mkdir /opt/config/
+COPY ./dist/docker_linux_$TARGETARCH*/study_xxqg /opt/study_xxqg
 
 COPY conf/config_default.yml /opt/config/config.yml
 
-RUN  ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
-     echo 'Asia/Shanghai' >/etc/timezone && apt-get -qq update \
-        && apt-get -qq install -y --no-install-recommends ca-certificates curl \
-    && apt-get update && apt-get install -y libx11-6 libgbm1 libasound2 libcairo2 libxshmfence1 libatspi2.0-0 libpango-1.0-0 libnss3  \
-    libatk1.0-0 libatk-bridge2.0-0 libcups2 libxrandr2 libxfixes3 libxdamage1 libxcomposite1 libxkbcommon0 \
-    && chmod -R 777 /opt/study_xxqg && cd /opt/ &&  ./study_xxqg --init
+RUN  chmod -R 777 /opt/study_xxqg && \
+     cd /opt/ && \
+     ./study_xxqg --init
+
 EXPOSE 8080
 
 VOLUME /opt/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN  ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
      apt-get -qq install -y --no-install-recommends ca-certificates curl && \
      apt-get install -y libx11-6 libgbm1 libasound2 libcairo2 libxshmfence1 libatspi2.0-0 libpango-1.0-0 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libxrandr2 libxfixes3 libxdamage1 libxcomposite1 libxkbcommon0 && \
      apt-get clean && \
+     rm -rf /var/lib/apt/lists/* && \
      mkdir /opt/config/
 
 COPY ./dist/docker_linux_$TARGETARCH*/study_xxqg /opt/study_xxqg


### PR DESCRIPTION
1. 启用docker构建缓存
2. 设置shm-size为2g
3. 仅编译docker所需的binary
4. 略微降低docker镜像体积